### PR TITLE
Generate ingest id from rtmp url

### DIFF
--- a/services/kafka.go
+++ b/services/kafka.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"sync"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
@@ -34,11 +35,11 @@ type KafkaService struct {
 
 // KafkaMessage defines the message structure
 type KafkaMessage struct {
-	Ingest    string `json:"ingest"`
-	IngestID  string `json:"ingestId"`
-	Timestamp string `json:"timestamp"`
-	Payload   string `json:"payload"`
-	Metadata  string `json:"metadata"`
+	Ingest    string                 `json:"ingest"`
+	IngestID  string                 `json:"ingestId"`
+	Timestamp string                 `json:"timestamp"`
+	Payload   string                 `json:"payload"`
+	Metadata  map[string]interface{} `json:"metadata"`
 }
 
 // NewKafkaService will instantiate an instance using the producer provided
@@ -91,9 +92,11 @@ func (k *KafkaService) StartBackgroundSend(sendWaitGroup *sync.WaitGroup, shutdo
 			messageValue := KafkaMessage{
 				Ingest:    "rtmp",
 				IngestID:  payload.ID,
-				Timestamp: "2021-08-31T14:51:36.507Z",
+				Timestamp: time.Now().Format(time.RFC3339),
 				Payload:   base64.StdEncoding.EncodeToString(payload.Data),
-				Metadata:  "{}",
+				Metadata: map[string]interface{}{
+					"rtmp_path": payload.ID,
+				},
 			}
 
 			k.SendMessage(messageKey, messageValue)

--- a/services/kafka.go
+++ b/services/kafka.go
@@ -90,7 +90,7 @@ func (k *KafkaService) StartBackgroundSend(sendWaitGroup *sync.WaitGroup, shutdo
 			messageKey := "01000000-0000-4000-8883-c7df300514ed"
 			messageValue := KafkaMessage{
 				Ingest:    "rtmp",
-				IngestID:  "4883C7DF300514ED",
+				IngestID:  payload.ID,
 				Timestamp: "2021-08-31T14:51:36.507Z",
 				Payload:   base64.StdEncoding.EncodeToString(payload.Data),
 				Metadata:  "{}",

--- a/services/video-ingest.go
+++ b/services/video-ingest.go
@@ -34,6 +34,7 @@ func (vs *VideoIngestService) IngestVideo(rtmpURL string) {
 	ingestID := getIngestIDFromURL(rtmpURL)
 	if ingestID == "" {
 		zap.S().Warn("ingestID is empty, not consuming video")
+
 		return
 	}
 
@@ -101,6 +102,7 @@ func getIngestIDFromURL(rtmpURL string) string {
 	parsed, err := url.Parse(rtmpURL)
 	if err != nil {
 		zap.S().Errorf("unable to parse rtmp url to create ingest id: %s", err)
+
 		return ""
 	}
 


### PR DESCRIPTION
**Problem**
We need to populate the kafka message from this service to the routing service with meaningful data. We have agreed to generate the ingest id from the path of the rtmp url.

**Solution**
- [x] Generate ingest id from url
- [x] Populate kafka message with meaningful info