### PR TITLE
Sanitise RTMP path for  Ingest ID 

### DIFF
--- a/services/video-ingest.go
+++ b/services/video-ingest.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"net/url"
+	"strings"
 	"sync"
 
 	ffmpeg "github.com/u2takey/ffmpeg-go"
@@ -105,6 +106,7 @@ func getIngestIDFromURL(rtmpURL string) string {
 
 		return ""
 	}
+	ingestID := strings.Replace(parsed.Path, "/", "-", -1)
 
-	return parsed.Path
+	return ingestID
 }

--- a/services/video-ingest.go
+++ b/services/video-ingest.go
@@ -106,6 +106,7 @@ func getIngestIDFromURL(rtmpURL string) string {
 
 		return ""
 	}
+
 	ingestID := strings.Replace(parsed.Path, "/", "-", -1)
 
 	return ingestID


### PR DESCRIPTION
 **Problem**
Currently ingest ID values are just the path from the RTMP url, however this may be problematic if we use these values in places like url parameters.

**Solution**
Sanitise the ingest ID values by replacing slashes with hyphens