### PR TITLE
Send video files and playlist output as events

### DIFF
--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	defer func() {
-		err := logger.Sync()
+		err = logger.Sync()
 		if err != nil {
 			log.Printf("error whilst syncing zap: %s\n", err)
 		}
@@ -74,7 +74,7 @@ func main() {
 	}
 
 	defer func() {
-		if err := producer.Close(); err != nil {
+		if err = producer.Close(); err != nil {
 			zap.S().Fatal(err)
 		}
 	}()

--- a/services/kafka.go
+++ b/services/kafka.go
@@ -16,6 +16,7 @@ import (
 type Payload struct {
 	ID      string
 	FrameNo int
+	Type    string
 	Data    []byte
 }
 
@@ -86,7 +87,7 @@ func (k *KafkaService) StartBackgroundSend(sendWaitGroup *sync.WaitGroup, shutdo
 	for {
 		select {
 		case payload := <-k.payloads:
-			zap.S().Debugf("Received video chunk: %d - %d", payload.FrameNo, len(payload.Data))
+			zap.S().Debugf("Submitting payload: %d - %s - %d", payload.FrameNo, payload.Type, len(payload.Data))
 
 			messageKey := payload.ID
 			messageValue := KafkaMessage{

--- a/services/kafka.go
+++ b/services/kafka.go
@@ -19,7 +19,7 @@ type Payload struct {
 	Filename    string
 	Type        string
 	Data        []byte `json:"-"`
-	EncodedData string `json:"Data"`
+	EncodedData string `json:"data"`
 }
 
 // KafkaOperations defines operations for kafka messaging

--- a/services/kafka.go
+++ b/services/kafka.go
@@ -41,7 +41,7 @@ type KafkaMessage struct {
 	Ingest    string                 `json:"ingest"`
 	IngestID  string                 `json:"ingestId"`
 	Timestamp string                 `json:"timestamp"`
-	Payload   string                 `json:"payload"`
+	Payload   *Payload               `json:"payload"`
 	Metadata  map[string]interface{} `json:"metadata"`
 }
 
@@ -92,17 +92,12 @@ func (k *KafkaService) StartBackgroundSend(sendWaitGroup *sync.WaitGroup, shutdo
 			zap.S().Debugf("Submitting payload: %d - %s - %d", payload.FrameNo, payload.Type, len(payload.Data))
 			payload.EncodedData = base64.StdEncoding.EncodeToString(payload.Data)
 
-			payloadJSON, err := json.Marshal(payload)
-			if err != nil {
-				zap.S().Fatalf("problem marshalling payload")
-			}
-
 			messageKey := payload.ID
 			messageValue := KafkaMessage{
 				Ingest:    "ingest-rtmp",
 				IngestID:  payload.ID,
 				Timestamp: time.Now().Format(time.RFC3339),
-				Payload:   string(payloadJSON),
+				Payload:   payload,
 				Metadata: map[string]interface{}{
 					"rtmp_path": payload.ID,
 				},

--- a/services/kafka.go
+++ b/services/kafka.go
@@ -14,10 +14,11 @@ import (
 
 // Payload defines the data contained in
 type Payload struct {
-	ID      string
-	FrameNo int
-	Type    string
-	Data    []byte
+	ID       string
+	FrameNo  int
+	Filename string
+	Type     string
+	Data     []byte
 }
 
 // KafkaOperations defines operations for kafka messaging

--- a/services/video-ingest.go
+++ b/services/video-ingest.go
@@ -1,24 +1,32 @@
 package services
 
 import (
-	"errors"
 	"io"
+	"io/ioutil"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 	"go.uber.org/zap"
+
+	"github.com/digicatapult/wasp-ingest-rtmp/util"
 )
 
 // VideoIngestService is a video ingest service
 type VideoIngestService struct {
+	outputDir string
+
 	ks KafkaOperations
 }
 
 // NewVideoIngestService instantiates a new instance
-func NewVideoIngestService(ks KafkaOperations) *VideoIngestService {
+func NewVideoIngestService(outputDir string, ks KafkaOperations) *VideoIngestService {
 	return &VideoIngestService{
+		outputDir: outputDir,
+
 		ks: ks,
 	}
 }
@@ -39,21 +47,29 @@ func (vs *VideoIngestService) IngestVideo(rtmpURL string) {
 		return
 	}
 
-	go vs.consumeVideo(ingestID, pipeReader, videoSendWaitGroup)
+	videoOutputDir := filepath.Join(vs.outputDir, ingestID)
+	err := util.CheckAndCreate(videoOutputDir)
+	if err != nil {
+		zap.S().Fatalf("unable to create temp video directory '%s': %s", videoOutputDir, err)
+	}
+
+	go vs.consumeVideo(ingestID, videoOutputDir, pipeReader, videoSendWaitGroup)
 
 	done := make(chan error)
 
-	const groupOfPictureSize = 52
-
 	go func() {
+		videoOutputPath := filepath.Join(videoOutputDir, `output%03d.ts`)
+
 		err := ffmpeg.Input(rtmpURL).
-			Output("pipe:", ffmpeg.KwArgs{
-				"f":         "h264",
-				"c:v":       "libx264",
-				"c:a":       "aac",
-				"profile:v": "baseline",
-				"movflags":  "frag_keyframe+empty_moov",
-				"g":         groupOfPictureSize,
+			Output(videoOutputPath, ffmpeg.KwArgs{
+				"f":                 "segment",
+				"c:v":               "libx264",
+				"an":                "",
+				"segment_time":      1,
+				"segment_list":      "pipe:1",
+				"segment_format":    "mpegts",
+				"segment_list_type": "m3u8",
+				"segment_list_size": 3,
 			}).
 			WithOutput(pipeWriter).
 			Run()
@@ -63,48 +79,77 @@ func (vs *VideoIngestService) IngestVideo(rtmpURL string) {
 		done <- err
 	}()
 
-	err := <-done
+	err = <-done
 	zap.S().Infof("Done (waiting for completion of send): %s", err)
 	videoSendWaitGroup.Wait()
 	shutdown <- true
 }
 
-func (vs *VideoIngestService) consumeVideo(ingestID string, reader io.Reader, videoSendWaitGroup *sync.WaitGroup) {
+func (vs *VideoIngestService) consumeVideo(ingestID, videoOutputDir string, reader io.Reader, videoSendWaitGroup *sync.WaitGroup) {
 	frameSize := 1000
 	frameCount := 0
 	buf := make([]byte, frameSize)
 
 	for {
-		count, err := io.ReadFull(reader, buf)
-		frameCount++
-
-		switch {
-		case count == 0 || errors.Is(err, io.EOF):
-			zap.S().Debug("end of stream reached")
-
-			return
-		case count != frameSize:
-			zap.S().Infof("end of stream reached, sending short chunk: %d, %s", count, err)
-		case err != nil:
-			zap.S().Errorf("read error: %d, %s", count, err)
-
-			if count == 0 {
-				return
-			}
+		_, err := reader.Read(buf)
+		// frameCount++
+		if err != nil {
+			zap.S().Fatalf("read error: %s", err)
 		}
+		// switch {
+		// case count == 0 || errors.Is(err, io.EOF):
+		// 	zap.S().Debug("end of stream reached")
+
+		// 	return
+		// case count != frameSize:
+		// 	zap.S().Infof("end of stream reached, sending short chunk: %d, %s", count, err)
+		// case err != nil:
+		// 	zap.S().Errorf("read error: %d, %s", count, err)
+
+		// 	if count == 0 {
+		// 		return
+		// 	}
+		// }
 
 		bufCopy := make([]byte, frameSize)
 		copy(bufCopy, buf)
 
-		payload := &Payload{
+		m3u8 := strings.TrimRight(string(bufCopy), "\x00")
+
+		lines := strings.Split(m3u8, "\n")
+
+		lastFile := lines[len(lines)-2]
+
+		lastFilePath := filepath.Join(videoOutputDir, lastFile)
+
+		zap.S().Infof("Path:'%s'", lastFilePath)
+
+		f, err := os.Open(lastFilePath)
+		if err != nil {
+			zap.S().Fatalf("unable to open file for reading %s: %s", lastFilePath, err)
+		}
+
+		bytes, err := ioutil.ReadAll(f)
+		if err != nil {
+			zap.S().Fatalf("unable to open file for reading %s: %s", lastFilePath, err)
+		}
+
+		metaPayload := &Payload{
 			ID:      ingestID,
+			Type:    "meta",
 			FrameNo: frameCount * frameSize,
 			Data:    bufCopy,
 		}
-
-		zap.S().Debugf("Video chunk: %d - %d", payload.FrameNo, len(payload.Data))
+		dataPayload := &Payload{
+			ID:      ingestID,
+			Type:    "data",
+			FrameNo: frameCount * frameSize,
+			Data:    bytes,
+		}
 		videoSendWaitGroup.Add(1)
-		vs.ks.PayloadQueue() <- payload
+		vs.ks.PayloadQueue() <- metaPayload
+		videoSendWaitGroup.Add(1)
+		vs.ks.PayloadQueue() <- dataPayload
 	}
 }
 

--- a/services/video-ingest.go
+++ b/services/video-ingest.go
@@ -106,6 +106,8 @@ func (vs *VideoIngestService) consumeVideo(
 		bufCopy := make([]byte, frameSize)
 		copy(bufCopy, buf)
 
+		zap.S().Infof("\n%s", string(bufCopy))
+
 		lastFile := getLastfilename(bufCopy)
 
 		lastFilePath := filepath.Join(videoOutputDir, filepath.Clean(lastFile))
@@ -124,7 +126,7 @@ func (vs *VideoIngestService) consumeVideo(
 			ID:      ingestID,
 			Type:    "meta",
 			FrameNo: frameCount * frameSize,
-			Data:    bufCopy,
+			Data:    []byte(strings.TrimRight(string(bufCopy), "\x00")),
 		}
 		dataPayload := &Payload{
 			ID:       ingestID,
@@ -138,6 +140,7 @@ func (vs *VideoIngestService) consumeVideo(
 		vs.ks.PayloadQueue() <- metaPayload
 		videoSendWaitGroup.Add(1)
 		vs.ks.PayloadQueue() <- dataPayload
+		frameCount++
 	}
 }
 

--- a/util/dir.go
+++ b/util/dir.go
@@ -2,15 +2,19 @@ package util
 
 import (
 	"os"
+
+	"github.com/pkg/errors"
 )
 
-// CheckAndCreate
+// CheckAndCreate will check if a folder path exists, otherwise create it (including parents)
 func CheckAndCreate(path string) error {
+	const dirPerms = 0o750
+
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(path, 0o777)
+		err = os.MkdirAll(path, dirPerms)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "folder not created")
 		}
 	}
 

--- a/util/dir.go
+++ b/util/dir.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"os"
+)
+
+// CheckAndCreate
+func CheckAndCreate(path string) error {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(path, 0o777)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/util/sarama-zap.go
+++ b/util/sarama-zap.go
@@ -7,15 +7,15 @@ type SaramaZapLogger struct{}
 
 // Print will Print a log message to zap info
 func (sz SaramaZapLogger) Print(v ...interface{}) {
-	zap.S().Info(v)
+	zap.S().Info(v...)
 }
 
 // Printf will Printf a log message to zap info
 func (sz SaramaZapLogger) Printf(format string, v ...interface{}) {
-	zap.S().Infof(format, v)
+	zap.S().Infof(format, v...)
 }
 
 // Println will Println a log message to zap info
 func (sz SaramaZapLogger) Println(v ...interface{}) {
-	zap.S().Info(v)
+	zap.S().Info(v...)
 }


### PR DESCRIPTION
**Problem**
We want to use hls to segment video and then send the video via kafka.

**Solution**
- Segment video using the segment formatting option in ffmpeg
    - 1 minute segments (roughly 100 - 400KB)
    - video files output to the outputdir cli arg
    - playlist file output to pipe
- Read playlist file from pipe to create meta event
- Trigger read video from  disk when meta event created
- Videos sent as data events